### PR TITLE
fix: install missing udpcast dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,7 @@ RUN apt-get -q update && \
         vsftpd \
         isc-dhcp-server \
         iproute2 \
+        udpcast \
         net-tools \
         # System utilities
         curl \


### PR DESCRIPTION
This fixes #6. The updcast package was not installed in the final docker image. This caused multicast to fail.