### PR TITLE
fix: symlink udp-sender to the location Fog is looking for it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,10 @@ RUN apt-get -q update && \
         bind9-dnsutils \
         && rm -rf /var/lib/apt/lists/*
 
+# symlink udp-sender because Fog looks at the wrong/old location.
+# multicast breaks without this
+RUN ln -s /usr/bin/udp-sender /usr/local/bin/udp-sender
+
 # Install architecture-specific secure boot packages
 RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         apt-get -q update && \


### PR DESCRIPTION
Hey,

This is a bit stupid on my side, but my earlier pr (#7) didn't actually fix the multicast issue. It did install udp-cast, however fog is still looking in the wrong location (`/usr/local/bin/udp-cast`). This pr works around this by creating a symlink from `/usr/bin/udp-cast` to `/usr/local/bin/udp-cast`.